### PR TITLE
Fixes deprecation warning for use of `container`

### DIFF
--- a/addon/utils/load-disqus-api.js
+++ b/addon/utils/load-disqus-api.js
@@ -2,8 +2,11 @@ import DisqusCache from 'ember-disqus/utils/disqus-cache';
 import Ember from 'ember';
 import defaultFor from 'ember-disqus/utils/default-for';
 
+const { getOwner } = Ember;
+
 export default function loadFilepickerApi(context, fileName) {
-  const ENV = context.container.lookupFactory('config:environment');
+  const owner = getOwner(context),
+    ENV = owner.resolveRegistration('config:environment');
 
   let documentIsReady, filePath, cachedValue, shortname, shouldLazyLoad;
 


### PR DESCRIPTION
Use of `container` in a helper triggers a deprecation warning from Ember 2.3 and later. This fixes that warning by opting in favor of using `getOwner`. See http://emberjs.com/deprecations/v2.x/#toc_injected-container-access for more info regarding the deprecation.
