### PR TITLE
Issue #10. Removed unecessary text

### DIFF
--- a/addon/templates/components/disqus-comments.hbs
+++ b/addon/templates/components/disqus-comments.hbs
@@ -1,5 +1,3 @@
 {{#if hasBlock}}
   {{yield}}
-{{else}}
-  Loading comments...
 {{/if}}

--- a/tests/integration/components/disqus-comments-test.js
+++ b/tests/integration/components/disqus-comments-test.js
@@ -11,11 +11,10 @@ test('it renders', function(assert) {
   // Handle any actions with this.on('myAction', function(val) { ... });
 
   this.set('setup', () => {
-    true;
+    return true;
   });
 
   this.render(hbs`{{disqus-comments identifier='index' setup=setup}}`);
 
-  assert.equal(this.$().text().trim(), 'Loading comments...');
-
+  assert.equal(window.disqus_identifier, "index", "component loaded");
 });


### PR DESCRIPTION
Problem https://github.com/sir-dunxalot/ember-disqus/issues/10

Text "Loading comments..." was always displaying. 
Disqus already provides a spinning widget that gives the user a feedback that comments are being loaded.
Also the text was not removed when changing routes.

Solution
Removed text and updated test